### PR TITLE
changed minimum cordova version to 7.x in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 # Installation
 
 ### Prerequisites
-1. Cordova 4.x or newer
+1. Cordova 7.x or newer
 2. Node 6.0 or newer
 3. Cordova CLI tools
 4. Android and iOS Cordova platforms


### PR DESCRIPTION
Changed cordova min version to 7.x. 

I wonder if it would be acceptable to add logic in the android.js file to determine if cordova version is 6.x or 7.x, then set the gradle build path.

If this logic idea is good, this SO post, which I don't fully comprehend, seems to suggest a possible solution for pulling the cordova version from the config.xml.  https://stackoverflow.com/a/42650842/8140320