### PR TITLE
replace compile to implementation for gradle build

### DIFF
--- a/hooks/android/android.js
+++ b/hooks/android/android.js
@@ -30,7 +30,7 @@ module.exports = {
    */
   nrTag: "\n// NEWRELIC ADDED\n" 
     + "buildscript {\n\tdependencies {\n\t\tclasspath 'com.newrelic.agent.android:agent-gradle-plugin:{AGENT_VER}'\n\t}\n}\n"
-    + "dependencies {\n\tcompile ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
+    + "dependencies {\n\timplementation ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
     + "{PLUGIN}"
     + "// NEWRELIC ADDED\n",
 


### PR DESCRIPTION
fix build:
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)
registerResGeneratingTask is deprecated, use registerGeneratedResFolders(FileCollection)

