### PR TITLE
Change to Implementation with the latest version of the repository.

### DIFF
--- a/hooks/android/android.js
+++ b/hooks/android/android.js
@@ -30,7 +30,7 @@ module.exports = {
    */
   nrTag: "\n// NEWRELIC ADDED\n" 
     + "buildscript {\n\tdependencies {\n\t\tclasspath 'com.newrelic.agent.android:agent-gradle-plugin:{AGENT_VER}'\n\t}\n}\n"
-    + "dependencies {\n\tcompile ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
+    + "dependencies {\n\timplementation ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
     + "{PLUGIN}"
     + "// NEWRELIC ADDED\n",
 


### PR DESCRIPTION
Yet another pull. request but with the latest version
change: Implementation instead of compile
reason : Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.