### PR TITLE
Fix for issue #33 Modified Compile to Implementation.

### DIFF
--- a/hooks/android/android.js
+++ b/hooks/android/android.js
@@ -30,7 +30,7 @@ module.exports = {
    */
   nrTag: "\n// NEWRELIC ADDED\n" 
     + "buildscript {\n\tdependencies {\n\t\tclasspath 'com.newrelic.agent.android:agent-gradle-plugin:{AGENT_VER}'\n\t}\n}\n"
-    + "dependencies {\n\tcompile ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
+    + "dependencies {\n\timplementation ('com.newrelic.agent.android:android-agent:{AGENT_VER}')\n}\n"
     + "{PLUGIN}"
     + "// NEWRELIC ADDED\n",
 


### PR DESCRIPTION
#33
This issue is occuring when we add this plugin to cordova android project. 
For gradle, we should use implementation instead of compile.