### PR TITLE
Update cyclical json stringify for consoleEvents

### DIFF
--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -108,7 +108,7 @@ var NewRelic = {
     },
 
     sendConsole(type, args) {
-        const argsStr = JSON.stringify(args);
+        const argsStr = JSON.stringify(decycle(args));
         this.send('MobileJSConsole', { consoleType: type, args: argsStr });
     },
 
@@ -494,6 +494,70 @@ const NewRelicEvent = class CustomEvent {
         [Validator.isObject, Validator.hasValidAttributes],
         `attributes '${attributes}' are not valid.`);
     }
+};
+
+// Taken from Douglas Crockford's cycle.js: https://github.com/douglascrockford/JSON-js
+const decycle = function decycle(object, replacer) {
+    "use strict";
+
+    var objects = new WeakMap();     // object to path mappings
+
+    return (function derez(value, path) {
+        var old_path;   // The path of an earlier occurance of value
+        var nu;         // The new object or array
+
+// If a replacer function was provided, then call it to get a replacement value.
+
+        if (replacer !== undefined) {
+            value = replacer(value);
+        }
+
+        if (
+            typeof value === "object"
+            && value !== null
+            && !(value instanceof Boolean)
+            && !(value instanceof Date)
+            && !(value instanceof Number)
+            && !(value instanceof RegExp)
+            && !(value instanceof String)
+        ) {
+
+// If the value is an object or array, look to see if we have already
+// encountered it. If so, return a {"$ref":PATH} object. This uses an
+// ES6 WeakMap.
+
+            old_path = objects.get(value);
+            if (old_path !== undefined) {
+                return {$ref: old_path};
+            }
+
+// Otherwise, accumulate the unique value and its path.
+
+            objects.set(value, path);
+
+// If it is an array, replicate the array.
+
+            if (Array.isArray(value)) {
+                nu = [];
+                value.forEach(function (element, i) {
+                    nu[i] = derez(element, path + "[" + i + "]");
+                });
+            } else {
+
+// If it is an object, replicate the object.
+
+                nu = {};
+                Object.keys(value).forEach(function (name) {
+                    nu[name] = derez(
+                        value[name],
+                        path + "[" + JSON.stringify(name) + "]"
+                    );
+                });
+            }
+            return nu;
+        }
+        return value;
+    }(object, "$"));
 };
 
 


### PR DESCRIPTION
There will be a `TypeError` when console outputs cyclical structures. Changes to now include circular references in `JSON.stringify` by decycling structures. Code to decycle structures taken from Douglas Crockford's decycle: https://github.com/douglascrockford/JSON-js.

- Cyclical objects will no longer be removed and will be replaced by `$ref: PATH`