### PR TITLE
fix: Prune cyclical structures in stringify

### DIFF
--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -108,7 +108,8 @@ var NewRelic = {
     },
 
     sendConsole(type, args) {
-        const argsStr = JSON.stringify(args);
+
+        const argsStr = JSON.stringify(args, getCircularReplacer());
         this.send('MobileJSConsole', { consoleType: type, args: argsStr });
     },
 
@@ -496,5 +497,22 @@ const NewRelicEvent = class CustomEvent {
     }
 };
 
+/**
+ * Source: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value
+ * Any copyright is dedicated to the Public Domain: https://creativecommons.org/publicdomain/zero/1.0/
+ */
+const getCircularReplacer = () => {
+    const seen = new WeakSet();
+    return (key, value) => {
+      if (typeof value === "object" && value !== null) {
+        if (seen.has(value)) {
+          return;
+        }
+        seen.add(value);
+      }
+      return value;
+    };
+};
+  
 
 module.exports = NewRelic;


### PR DESCRIPTION
- Avoid OOM issue on Android when a big enough circular structure is passed in.
- Removes cyclical structure