### PR TITLE
fix: add empty check for regex groups

### DIFF
--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -172,10 +172,13 @@
         }
         
         NSMutableDictionary* stackTraceElement = [NSMutableDictionary new];
-        stackTraceElement[@"method"] = [line substringWithRange:[result[0] rangeAtIndex:1]];
-        stackTraceElement[@"file"] = [line substringWithRange:[result[0] rangeAtIndex:3]];
-        NSNumber* lineNum = @([[line substringWithRange:[result[0] rangeAtIndex:4]] intValue]);
-        stackTraceElement[@"line"] = lineNum;
+        NSRange methodRange = [result[0] rangeAtIndex:1];
+        NSRange fileRange = [result[0] rangeAtIndex:3];
+        NSRange lineNumRange = [result[0] rangeAtIndex:4];
+        
+        stackTraceElement[@"method"] = methodRange.length == 0 ? @" " : [line substringWithRange:methodRange];
+        stackTraceElement[@"file"] = fileRange.length == 0 ? @" " : [line substringWithRange:fileRange];
+        stackTraceElement[@"line"] = lineNumRange.length == 0 ? [NSNumber numberWithInt:1] : @([[line substringWithRange:lineNumRange] intValue]);
         
         [stackFramesArr addObject:stackTraceElement];
     }

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -121,10 +121,12 @@ exports.defineAutoTests = () => {
       spyOn(cordova, "exec").and.callThrough();
       spyOn(window.console, "warn").and.callThrough();
 
+      // should parse errors with missing fields
       let exampleError = new Error();
       exampleError.name = 'fakeErrorName';
       exampleError.message = 'fakeMsg';
-      exampleError.stack = 'fakeStack';
+      exampleError.stack = 'ionic://com.example.app.poc:8100/plugins/newrelic-cordova-plugin/www/js/missingmethod.js:123:45\nmissingfile@:1:2345\nmissinglinenum@ionic://com.example.app.poc:8100/example.js::\nregularstackline@ionic://com.example.app.poc:8100/example.js:1:23456';
+      // will crash if unable to execute
       window.NewRelic.recordError(exampleError);
       window.NewRelic.recordError(new TypeError);
       window.NewRelic.recordError(new EvalError);
@@ -141,6 +143,10 @@ exports.defineAutoTests = () => {
       let numOfNativeCalls = cordova.exec.calls.count() - window.console.warn.calls.count();
       expect(numOfNativeCalls).toBe(6);
       expect(window.NewRelic.recordError).toHaveBeenCalledTimes(10);
+    });
+
+    it('should parse JS error with missing fields', () => {
+
     });
 
     it('should have currentSessionId', () => {


### PR DESCRIPTION
On iOS, the regex grouping for JS errors can be empty/null. This adds a check for empty/null values so that `substringwithRange` will not run on -1 value. 