### PR TITLE
Add optional attributes for recordError

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ By default, these configurations are already set to true on agent start.
 ```
 
 ## Error Reporting
-### recordError(err: [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)) : void;
+### recordError(err: [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error), attributes?: {[key: string]: boolean | number | string}) : void;
 Records JavaScript errors for Cordova. It is useful to add this method by adding it to the error handler of the framework that you are using. Here are some examples below:
 
 ### Angular

--- a/src/android/NewRelicCordovaPlugin.java
+++ b/src/android/NewRelicCordovaPlugin.java
@@ -208,12 +208,20 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                     final String errorMessage = args.getString(1);
                     final String errorStack = args.getString(2);
                     final Boolean isFatal = args.getBoolean(3);
+                    final JSONObject attributesAsJson = args.getJSONObject(4);
 
                     HashMap<String, Object> exceptionMap = new HashMap<>();
                     try {
                         exceptionMap.put("name", errorName);
                         exceptionMap.put("message", errorMessage);
                         exceptionMap.put("isFatal", isFatal);
+                        if (attributesAsJson != null) {
+                            final Map<String, Object> attributes = new Gson().fromJson(String.valueOf(attributesAsJson),
+                                Map.class);
+                            for (String key : attributes.keySet()) {
+                                exceptionMap.put(key, attributes.get(key));
+                            }
+                        }
                     } catch (IllegalArgumentException e) {
                         Log.w("NRMA", e.getMessage());
                     }

--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -197,6 +197,7 @@
     NSString* errorMessage = [command.arguments objectAtIndex:1];
     NSString* errorStack = [command.arguments objectAtIndex:2];
     NSString* isFatal = @"false";
+    NSDictionary* errorAttributes = [command.arguments objectAtIndex:4];
 
     if ([[command.arguments objectAtIndex:3] boolValue] == YES) {
         isFatal = @"true";
@@ -207,6 +208,11 @@
     attributes[@"cause"] = errorMessage;
     attributes[@"reason"] = errorMessage;
     attributes[@"fatal"] = isFatal;
+    if (errorAttributes != nil && ![errorAttributes isKindOfClass:[NSNull class]]) {
+        for(id key in errorAttributes) {
+            attributes[key] = errorAttributes[key];
+        }
+    }
     
     NSMutableArray* stackTraceArr = [self parseStackTrace:errorStack];
     attributes[@"stackTraceElements"] = stackTraceArr;

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -137,7 +137,8 @@ exports.defineAutoTests = () => {
       // should parse errors with non-empty custom attributes
       let errorAttributes = new Map([
         ["errorKey1", "errorValue1"],
-        ["errorKey2", "errorValue2"]
+        ["errorKey2", 2],
+        ["errorKey3", true]
       ]);
       window.NewRelic.recordError(exampleError, errorAttributes);
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -134,6 +134,19 @@ exports.defineAutoTests = () => {
       window.NewRelic.recordError(new ReferenceError);
       window.NewRelic.recordError(new Error);
 
+      // should parse errors with non-empty custom attributes
+      let errorAttributes = new Map([
+        ["errorKey1", "errorValue1"],
+        ["errorKey2", "errorValue2"]
+      ]);
+      window.NewRelic.recordError(exampleError, errorAttributes);
+
+      // should parse errors with null custom attributes
+      window.NewRelic.recordError(exampleError, null);
+
+      // should parse errors with empty custom attributes
+      window.NewRelic.recordError(exampleError, {});
+
       // Bad arguments
       window.NewRelic.recordError(undefined);
       window.NewRelic.recordError(null);
@@ -141,8 +154,8 @@ exports.defineAutoTests = () => {
       window.NewRelic.recordError(true);
 
       let numOfNativeCalls = cordova.exec.calls.count() - window.console.warn.calls.count();
-      expect(numOfNativeCalls).toBe(6);
-      expect(window.NewRelic.recordError).toHaveBeenCalledTimes(10);
+      expect(numOfNativeCalls).toBe(9);
+      expect(window.NewRelic.recordError).toHaveBeenCalledTimes(13);
     });
 
     it('should parse JS error with missing fields', () => {

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -125,8 +125,13 @@ var NewRelic = {
     /**
      * Records JavaScript errors for Cordova.
      * @param {Error} err The error to record.
+     * @param {Map<string, string|number>} attributes Optional attributes that will be appended to the handled exception event created in insights.
      */
-    recordError: function(err, cb, fail) {
+    recordError: function(err, attributes={}, cb, fail) {
+        let errorAttributes = attributes instanceof Map ? Object.fromEntries(attributes) : attributes;
+        if (attributes === null) {
+            errorAttributes = {};
+        }
         if (err) {
             var error;
 
@@ -139,7 +144,7 @@ var NewRelic = {
             }
 
             if(error !== undefined) {
-                cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [error.name, error.message, error.stack, false]);
+                cordova.exec(cb, fail, "NewRelicCordovaPlugin", "recordError", [error.name, error.message, error.stack, false, errorAttributes]);
             } else {
                 window.console.warn('Undefined error in NewRelic.recordError');
             }

--- a/www/js/newrelic.js
+++ b/www/js/newrelic.js
@@ -125,7 +125,7 @@ var NewRelic = {
     /**
      * Records JavaScript errors for Cordova.
      * @param {Error} err The error to record.
-     * @param {Map<string, string|number>} attributes Optional attributes that will be appended to the handled exception event created in insights.
+     * @param {Map<string, boolean|number|string>} attributes Optional attributes that will be appended to the handled exception event created in insights.
      */
     recordError: function(err, attributes={}, cb, fail) {
         let errorAttributes = attributes instanceof Map ? Object.fromEntries(attributes) : attributes;


### PR DESCRIPTION
### Context
This PR allows optional custom attributes for recordError in the Cordova plugin.

### Description
The Javascript and native (Objective-C, Java) code for recordError has been modified to handle an additional optional parameter for custom attributes to be recorded. The unit tests for recordError have been modified to test this new functionality of recording custom attributes. In addition, the README has been updated to reflect the update to recordError.