### PR TITLE
chore: Update native agents to Android 7.6.15 and iOS 7.6.1 (#124)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+# 7.0.13
+
+- Native Android agent updated to version 7.6.15
+- Native iOS agent updated to version 7.6.1
+
+
+
 # 7.0.12
 
 - Native Android agent updated to version 7.6.14

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-cordova-plugin",
-  "version": "7.0.12",
+  "version": "7.0.13",
   "description": "New Relic Cordova Plugin for iOS and Android",
   "repo": "https://github.com/newrelic/newrelic-cordova-plugin/",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-  id="newrelic-cordova-plugin" version="7.0.12">
+  id="newrelic-cordova-plugin" version="7.0.13">
   <name>NewRelic</name>
   <description>New Relic Cordova Plugin for iOS and Android</description>
   <author>New Relic</author>
@@ -18,7 +18,7 @@
     <engine name="cordova-android" version=">=5.0.0" />
   </engines>
 
-  <preference name="PLUGIN_VERSION" default="7.0.12" />
+  <preference name="PLUGIN_VERSION" default="7.0.13" />
   <preference name="CRASH_REPORTING_ENABLED" default="true" />
   <preference name="DISTRIBUTED_TRACING_ENABLED" default="true" />
   <preference name="INTERACTION_TRACING_ENABLED" default="true" />
@@ -79,7 +79,7 @@
         <source url="https://cdn.cocoapods.org/" />
       </config>
       <pods use-frameworks="true">
-        <pod name="NewRelicAgent" spec="~>7.6.0" />
+        <pod name="NewRelicAgent" spec="~>7.6.1" />
       </pods>
     </podspec>
 
@@ -89,7 +89,7 @@
 
   <platform name="android">
     <preference name="ANDROID_APP_TOKEN" default="x" />
-    <preference name="ANDROID_AGENT_VER" default="7.6.14" />
+    <preference name="ANDROID_AGENT_VER" default="7.6.15" />
 
     <config-file target="AndroidManifest.xml" parent="/*">
       <uses-permission android:name="android.permission.INTERNET" />


### PR DESCRIPTION
- Updated Android agent from 7.6.14 to 7.6.15
- Updated iOS agent from 7.6.0 to 7.6.1
- Bumped plugin version to 7.0.13