### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -17,6 +17,9 @@
 
 name: iOS Testsuite
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore:


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/9](https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/9)

Add an explicit workflow-level `permissions` block with least privilege.

Best fix here: in `.github/workflows/ios.yml`, add:

```yml
permissions:
  contents: read
```

right after the workflow `name` (before `on:`). This applies to all jobs unless overridden and preserves current functionality for checkout/build/test steps while restricting token scope.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
