### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_agent_version.yml
+++ b/.github/workflows/update_agent_version.yml
@@ -8,6 +8,9 @@ on:
       IS_ANDROID_AGENT:
         required: true
         type: boolean
+permissions:
+  contents: write
+  pull-requests: write
 jobs:
   update_agent_version:
     name: Update Native Agent version on Cordova


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/10](https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/10)

Add an explicit `permissions` block to this workflow to enforce least privilege while preserving current behavior.  
Because the job pushes commits and creates PRs, it needs:
- `contents: write` (for pushing branches/commits),
- `pull-requests: write` (for creating PRs via `gh pr create`).

Best single fix: add workflow-level `permissions` immediately after the `on`/inputs section and before `jobs`, so all jobs (current and future) inherit correct minimal permissions unless overridden.

File to change:
- `.github/workflows/update_agent_version.yml`  
Insert:
```yml
permissions:
  contents: write
  pull-requests: write
```

No imports/methods/dependencies required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
