### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,6 +29,9 @@ on:
       - 'LICENSE'
       - '.eslint*'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Android ${{ matrix.versions.android }} Test


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/11](https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/11)

Add an explicit `permissions` block in `.github/workflows/android.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. The minimal safe starting point for this workflow is:

- `contents: read`

This preserves current functionality for checkout and read-only repo operations while preventing accidental broader token access if repo/org defaults are permissive or later changed. No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
