### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -131,6 +131,8 @@ jobs:
   update-documentation:
     needs: create-release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     env:
       # --- CONFIG: Update these per repository ---
       AGENT_NAME: "cordova"


### PR DESCRIPTION
Potential fix for [https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/12](https://github.com/newrelic/newrelic-cordova-plugin/security/code-scanning/12)

Add an explicit `permissions` block to the `update-documentation` job in `.github/workflows/create-release.yml`.

Best fix (least functional impact): set:

```yml
permissions:
  contents: read
```

for `update-documentation`, since this job checks out repositories and uses a separate PAT (`BOT_PAT`) for operations that require write access (push/PR on `newrelic/docs-website`). This keeps `GITHUB_TOKEN` constrained while preserving current behavior.

Change location: in `.github/workflows/create-release.yml`, inside `jobs.update-documentation`, directly under `runs-on`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
