### PR TITLE
Default LOG_LEVEL to WARNING and separate DEBUG from AUDIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Currently, the plugin supports the following agent configuration options:
     * Possible values are `true` and `false`. Defaults to `true`.
 * `LOG_LEVEL`: Specifies the log level.
     * Possible values are `ERROR` (least verbose), `WARNING` `INFO`, `VERBOSE`, `DEBUG`, `AUDIT` (most verbose).
-    * Defaults to `INFO` on Android and `WARNING` on iOS.
+    * Defaults to `WARNING`.
 * `WEB_VIEW_INSTRUMENTATION` (iOS ONLY): Enable (default) or disable automatic WKWebView instrumentation.
     * Possible values are `true` and `false`. Defaults to `true`.
 * `COLLECTOR_ADDRESS`: Specifies the URI authority component of the harvest data upload endpoint.
@@ -304,7 +304,7 @@ NewRelic.logWarn("Warning message indicating a potential issue");
 NewRelic.logError("Error message indicating a failure");
 ```
 ## [log] (level: string, message: string): void;
-> Logs a message with a specified level. The level indicates the severity or importance of the message. Common levels include "info", "warn", "error", "debug", and "verbose".
+> Logs a message with a specified level. The level indicates the severity or importance of the message. Valid levels are `"ERROR"`, `"WARNING"`, `"INFO"`, `"VERBOSE"`, `"DEBUG"`, and `"AUDIT"`.
 ```js
 NewRelic.log("INFO", "User logged in successfully");
 ```

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
   <preference name="INTERACTION_TRACING_ENABLED" default="true" />
   <preference name="DEFAULT_INTERACTIONS_ENABLED" default="true" />
   <preference name="LOGGING_ENABLED" default="true" />
-  <preference name="LOG_LEVEL" default="default" />
+  <preference name="LOG_LEVEL" default="WARNING" />
   <preference name="WEB_VIEW_INSTRUMENTATION" default="true" />
   <preference name="COLLECTOR_ADDRESS" default="x" />
   <preference name="CRASH_COLLECTOR_ADDRESS" default="x" />

--- a/src/android/NewRelicCordovaPlugin.java
+++ b/src/android/NewRelicCordovaPlugin.java
@@ -90,23 +90,35 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                 NewRelic.disableFeature(FeatureFlag.BackgroundReporting);
             }
 
-            Map<String, Integer> strToLogLevel = new HashMap<>();
-            strToLogLevel.put("ERROR", AgentLog.ERROR);
-            strToLogLevel.put("WARNING", AgentLog.WARN);
-            strToLogLevel.put("INFO", AgentLog.INFO);
-            strToLogLevel.put("VERBOSE", AgentLog.VERBOSE);
-            strToLogLevel.put("AUDIT", AgentLog.AUDIT);
+            Map<String, Integer> strToAgentLogLevel = new HashMap<>();
+            strToAgentLogLevel.put("ERROR", AgentLog.ERROR);
+            strToAgentLogLevel.put("WARNING", AgentLog.WARN);
+            strToAgentLogLevel.put("INFO", AgentLog.INFO);
+            strToAgentLogLevel.put("VERBOSE", AgentLog.VERBOSE);
+            strToAgentLogLevel.put("DEBUG", AgentLog.DEBUG);
+            strToAgentLogLevel.put("AUDIT", AgentLog.AUDIT);
 
-            int logLevel = AgentLog.INFO;
-            String configLogLevel = preferences.getString("loglevel", "INFO").toUpperCase();
-            if (strToLogLevel.containsKey(configLogLevel)) {
-                logLevel = strToLogLevel.get(configLogLevel);
+            Map<String, LogLevel> strToLogLevel = new HashMap<>();
+            strToLogLevel.put("ERROR", LogLevel.ERROR);
+            strToLogLevel.put("WARNING", LogLevel.WARN);
+            strToLogLevel.put("INFO", LogLevel.INFO);
+            strToLogLevel.put("VERBOSE", LogLevel.VERBOSE);
+            strToLogLevel.put("DEBUG", LogLevel.DEBUG);
+            // LogLevel enum has no AUDIT; fall back to DEBUG (deepest available).
+            strToLogLevel.put("AUDIT", LogLevel.DEBUG);
+
+            int logLevel = AgentLog.WARN;
+            LogLevel reportingLogLevel = LogLevel.WARN;
+            String configLogLevel = preferences.getString("loglevel", "WARNING").toUpperCase();
+            if (strToAgentLogLevel.containsKey(configLogLevel)) {
+                logLevel = strToAgentLogLevel.get(configLogLevel);
+                reportingLogLevel = strToLogLevel.get(configLogLevel);
             }
 
             String collectorAddress = preferences.getString("collector_address", null);
             String crashCollectorAddress = preferences.getString("crash_collector_address", null);
 
-            LogReporting.setLogLevel(LogLevel.VERBOSE);
+            LogReporting.setLogLevel(reportingLogLevel);
             NewRelic newRelic = NewRelic.withApplicationToken(appToken)
                     .withApplicationFramework(ApplicationFramework.Cordova, pluginVersion)
                     .withLoggingEnabled(preferences.getString("logging_enabled", "true").toLowerCase().equals("true"))
@@ -548,6 +560,8 @@ public class NewRelicCordovaPlugin extends CordovaPlugin {
                     strToLogLevel.put("WARNING", LogLevel.WARN);
                     strToLogLevel.put("INFO", LogLevel.INFO);
                     strToLogLevel.put("VERBOSE", LogLevel.VERBOSE);
+                    strToLogLevel.put("DEBUG", LogLevel.DEBUG);
+                    // LogLevel enum has no AUDIT; fall back to DEBUG (deepest available).
                     strToLogLevel.put("AUDIT", LogLevel.DEBUG);
 
                     LogLevel logLevel = strToLogLevel.get(level);

--- a/src/ios/NewRelicCordovaPlugin.m
+++ b/src/ios/NewRelicCordovaPlugin.m
@@ -71,6 +71,7 @@
             @"WARNING": [NSNumber numberWithInt:NRLogLevelWarning],
             @"INFO": [NSNumber numberWithInt:NRLogLevelInfo],
             @"VERBOSE": [NSNumber numberWithInt:NRLogLevelVerbose],
+            @"DEBUG": [NSNumber numberWithInt:NRLogLevelDebug],
             @"AUDIT": [NSNumber numberWithInt:NRLogLevelAudit],
         };
         if ([logDict objectForKey:[config[@"log_level"] uppercaseString]]) {
@@ -540,6 +541,7 @@
         @"WARNING": [NSNumber numberWithInt:NRLogLevelWarning],
         @"INFO": [NSNumber numberWithInt:NRLogLevelInfo],
         @"VERBOSE": [NSNumber numberWithInt:NRLogLevelVerbose],
+        @"DEBUG": [NSNumber numberWithInt:NRLogLevelDebug],
         @"AUDIT": [NSNumber numberWithInt:NRLogLevelAudit],
     };
     if ([logDict objectForKey:[level uppercaseString]]) {


### PR DESCRIPTION
- plugin.xml: LOG_LEVEL default changed from "default" (no-op) to "WARNING"
- Android: default agent log level now AgentLog.WARN; LogReporting honors the configured LOG_LEVEL instead of being hardcoded to VERBOSE
- Android & iOS: added DEBUG as a first-class log level in both the init and runtime log() handler maps so it is no longer conflated with AUDIT
- README: documented unified WARNING default and corrected the valid level strings for NewRelic.log()