### PR TITLE
feat: add Swift Package Manager support for cordova-ios 8+

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -51,19 +51,29 @@ jobs:
         run: |
           VERSION="${{ steps.get_version.outputs.version }}"
 
-          # Extract the section for this version from CHANGELOG.md
-          # Read from the version header until the next version header or end of file
-          RELEASE_NOTES=$(awk "/^# ${VERSION}/,/^# [0-9]/" CHANGELOG.md | sed '1d;$d' | sed '/^$/d')
+          # Escape regex metacharacters (esp. dots in semver) so 7.1.5 doesn't
+          # also match 7X1Y5 etc. when the version is interpolated into a regex.
+          ESC_VERSION=$(printf '%s' "$VERSION" | sed 's/[][\\.*^$(){}+?|]/\\&/g')
 
-          # If empty, try to get the first entry
+          # Extract bullets between `# <VERSION>` and the next `# <digit>` header.
+          # The previous awk range pattern (`/^# ${VERSION}/,/^# [0-9]/`) failed
+          # because the end pattern matched the start line itself, collapsing the
+          # range to a single header line and producing empty notes (or, in the
+          # broken fallback, dumping every version header in the file).
+          RELEASE_NOTES=$(awk -v ver="$ESC_VERSION" '
+            $0 ~ "^# " ver "$" { in_section = 1; next }
+            in_section && /^# [0-9]/ { in_section = 0 }
+            in_section { print }
+          ' CHANGELOG.md | sed '/^[[:space:]]*$/d')
+
           if [ -z "$RELEASE_NOTES" ]; then
-            RELEASE_NOTES=$(awk '/^# [0-9]/,/^# [0-9]/' CHANGELOG.md | head -n -1 | sed '1d')
+            echo "::warning::No CHANGELOG.md section found for version $VERSION."
+            RELEASE_NOTES="See [CHANGELOG.md](./CHANGELOG.md) for details."
           fi
 
-          echo "Release notes:"
+          echo "Release notes for v$VERSION:"
           echo "$RELEASE_NOTES"
 
-          # Save to output using heredoc for multiline
           {
             echo 'release_notes<<EOF'
             echo "$RELEASE_NOTES"

--- a/.github/workflows/update-native-agents.yml
+++ b/.github/workflows/update-native-agents.yml
@@ -145,10 +145,22 @@ jobs:
           # Update Android agent version
           sed -i "s/<preference name=\"ANDROID_AGENT_VER\" default=\".*\" \/>/<preference name=\"ANDROID_AGENT_VER\" default=\"$ANDROID_VERSION\" \/>/" plugin.xml
 
-          # Update iOS agent version
-          sed -i "s/<pod name=\"NewRelicAgent\" spec=\"~>.*\" \/>/<pod name=\"NewRelicAgent\" spec=\"~>$IOS_VERSION\" \/>/" plugin.xml
+          # Update iOS agent CocoaPods spec (preserves the nospm attribute used for SPM dual-mode)
+          sed -i "s/<pod name=\"NewRelicAgent\" spec=\"~>[^\"]*\"/<pod name=\"NewRelicAgent\" spec=\"~>$IOS_VERSION\"/" plugin.xml
 
           echo "Updated plugin.xml"
+
+      - name: Update Package.swift (SPM iOS agent pin)
+        if: steps.check_updates.outputs.needs_update == 'true' && steps.check_updates.outputs.ios_updated == 'true'
+        run: |
+          IOS_VERSION="${{ steps.ios_version.outputs.version }}"
+
+          # Update the exact pin on newrelic-ios-agent-spm. Anchored on the package URL so we
+          # only touch this dependency and never a future Swift package's "exact:" pin.
+          sed -i "s|\(newrelic-ios-agent-spm\"[^)]*exact:[[:space:]]*\"\)[^\"]*\"|\1$IOS_VERSION\"|" Package.swift
+
+          echo "Updated Package.swift"
+          grep "newrelic-ios-agent-spm" Package.swift
 
       - name: Update package.json
         if: steps.check_updates.outputs.needs_update == 'true'
@@ -201,7 +213,7 @@ jobs:
             - Updated iOS agent from ${{ steps.current_versions.outputs.current_ios }} to ${{ steps.ios_version.outputs.version }}
             - Bumped plugin version to ${{ steps.new_plugin_version.outputs.new_version }}
           branch: update-native-agents-${{ steps.new_plugin_version.outputs.new_version }}
-          base: develop
+          base: master
           delete-branch: true
           title: 'chore: Update native agents to Android ${{ steps.android_version.outputs.version }} and iOS ${{ steps.ios_version.outputs.version }}'
           body: |
@@ -210,12 +222,13 @@ jobs:
             This PR updates the native agent versions:
 
             - **Android Agent**: ${{ steps.current_versions.outputs.current_android }} → ${{ steps.android_version.outputs.version }}
-            - **iOS Agent**: ${{ steps.current_versions.outputs.current_ios }} → ${{ steps.ios_version.outputs.version }}
+            - **iOS Agent**: ${{ steps.current_versions.outputs.current_ios }} → ${{ steps.ios_version.outputs.version }} (CocoaPods spec **and** SPM `Package.swift` pin)
             - **Plugin Version**: ${{ steps.current_versions.outputs.current_plugin }} → ${{ steps.new_plugin_version.outputs.new_version }}
 
             ## Files Updated
 
             - `plugin.xml`
+            - `Package.swift`
             - `package.json`
             - `CHANGELOG.md`
 

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ typings/
 
 package-lock.json
 .vscode/
+
+# Swift Package Manager
+.build/
+.swiftpm/
+Package.resolved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+# 7.1.5
+
+- Added Swift Package Manager support for cordova-ios 8+ (CocoaPods remains the install path on cordova-ios < 8)
+- Native iOS agent updated to version 7.7.2
+
+
+
 # 7.1.4
 
 - Native Android agent updated to version 7.7.5

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.9
+/*
+ * Copyright (c) 2022-present New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import PackageDescription
+
+let package = Package(
+    name: "newrelic-cordova-plugin",
+    platforms: [
+        .iOS(.v15)
+    ],
+    products: [
+        .library(
+            name: "newrelic-cordova-plugin",
+            targets: ["NewRelicCordovaPlugin"]
+        )
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apache/cordova-ios.git", from: "8.0.0"),
+        .package(url: "https://github.com/newrelic/newrelic-ios-agent-spm", exact: "7.7.2")
+    ],
+    targets: [
+        .target(
+            name: "NewRelicCordovaPlugin",
+            dependencies: [
+                .product(name: "Cordova", package: "cordova-ios"),
+                .product(name: "NewRelic", package: "newrelic-ios-agent-spm")
+            ],
+            path: "src/ios",
+            publicHeadersPath: "."
+        )
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,34 @@ Finally, copy the application tokens from your New Relic applications page, and 
 
 - Depends on New Relic iOS/XCFramework and Android agents
 
+### iOS Setup: deployment target
+
+The New Relic iOS agent (and therefore this plugin) requires a minimum
+deployment target of **iOS 15.0**. Add the following to your app's
+`config.xml`:
+
+```xml
+<platform name="ios">
+    <preference name="deployment-target" value="15.0" />
+</platform>
+```
+
+Applies to both **SPM** (cordova-ios 8+) and **CocoaPods** (cordova-ios < 8).
+
+If you skip this step on cordova-ios 8, `cordova build ios` fails with an
+error that names `CordovaPlugins`, not New Relic, which makes the cause
+non-obvious:
+
+```text
+error: The package product 'newrelic-cordova-plugin' requires minimum
+platform version 15.0 for the iOS platform, but this target supports 13.0
+(in target 'CordovaPlugins' from project 'CordovaPlugins')
+```
+
+cordova-ios 8 generates the `CordovaPlugins` aggregator at `.iOS(.v13)` by
+default; setting `deployment-target` to `15.0` raises it to match this
+plugin's `Package.swift` requirement.
+
 ## Adding the plugin
 Change to your Cordova project directory and add the plugin to your project using the Cordova command line tool. The `--variable` argument is used to pass application tokens to the plugin.
 ```

--- a/hooks/ios/ios.js
+++ b/hooks/ios/ios.js
@@ -54,6 +54,11 @@ module.exports = {
    * @returns {string} - location of project's Xcode .pbxproj file
    */
   xcodePath: function (context) {
+
+    var appProjectPath = path.join("platforms", "ios", "App.xcodeproj", "project.pbxproj");
+    if (fs.existsSync(appProjectPath)) {
+      return appProjectPath;
+    }
     return path.join("platforms", "ios", newrelic.appName(context) + ".xcodeproj", "project.pbxproj");
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "newrelic-cordova-plugin",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "New Relic Cordova Plugin for iOS and Android",
   "repo": "https://github.com/newrelic/newrelic-cordova-plugin/",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,7 +6,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-  id="newrelic-cordova-plugin" version="7.1.4">
+  id="newrelic-cordova-plugin" version="7.1.5">
   <name>NewRelic</name>
   <description>New Relic Cordova Plugin for iOS and Android</description>
   <author>New Relic</author>
@@ -18,7 +18,7 @@
     <engine name="cordova-android" version=">=5.0.0" />
   </engines>
 
-  <preference name="PLUGIN_VERSION" default="7.1.4" />
+  <preference name="PLUGIN_VERSION" default="7.1.5" />
   <preference name="CRASH_REPORTING_ENABLED" default="true" />
   <preference name="DISTRIBUTED_TRACING_ENABLED" default="true" />
   <preference name="INTERACTION_TRACING_ENABLED" default="true" />
@@ -36,7 +36,7 @@
   <preference name="LOG_REPORTING_ENABLED" default="true" />
 
 
-  <platform name="ios">
+  <platform name="ios" package="swift">
     <preference name="IOS_APP_TOKEN" default="x" />
 
     <js-module name="NewRelic" src="www/js/newrelic.js">
@@ -79,7 +79,7 @@
         <source url="https://cdn.cocoapods.org/" />
       </config>
       <pods use-frameworks="true">
-        <pod name="NewRelicAgent" spec="~>7.7.1" />
+        <pod name="NewRelicAgent" spec="~>7.7.2" nospm="true" />
       </pods>
     </podspec>
 


### PR DESCRIPTION
## What & Why

cordova-ios 8 introduces Swift Package Manager (SPM) as an alternative to CocoaPods for resolving native iOS dependencies. The plugin currently declares its iOS dependency only through `<podspec>`, so apps adopting cordova-ios 8 cannot integrate it.

This PR adds **dual-mode** resolution from a single source of truth:

| Consuming app's cordova-ios | Resolution path | Why |
|---|---|---|
| `>= 8` | **SPM** via `Package.swift` | cordova-ios 8 reads `package="swift"` on `<platform>` and uses the `Package.swift` we now ship. Pods marked `nospm="true"` are skipped (replaced by SPM). |
| `< 8` | **CocoaPods** via `<podspec>` (unchanged) | Older cordova-ios silently ignores `package="swift"` and `nospm="true"`, so the existing podspec block drives the install. |

No behavior change for current Pods users.

## Changes

- **`Package.swift`** (new) — `swift-tools-version:5.9`, iOS 15+ floor (matches the `newrelic-ios-agent-spm` package), depends on `cordova-ios from "8.0.0"` and `newrelic-ios-agent-spm exact "7.7.2"`. Target `NewRelicCordovaPlugin` reads from `src/ios` with `publicHeadersPath: "."` (the existing ObjC headers and source live there with no subdirectories).
- **`plugin.xml`** — added `package="swift"` to `<platform name="ios">` and `nospm="true"` to the `NewRelicAgent` pod entry. iOS agent bumped `~>7.7.1` → `~>7.7.2`. Plugin version `7.1.4` → `7.1.5`.
- **`hooks/ios/ios.js`** — prefer `platforms/ios/App.xcodeproj` when it exists (cordova-ios 8 SPM project naming) and fall back to the legacy `<AppName>.xcodeproj` path. Without this the post-install hook can't find the project under cordova-ios 8.
- **`.github/workflows/update-native-agents.yml`** — added a step that updates `Package.swift`'s `exact:` pin alongside the existing `plugin.xml` pod sed, and changed the auto-PR target branch from `develop` to `master`. The pod sed pattern was tightened so it only touches the version and preserves the new `nospm="true"` attribute.
- **`.gitignore`** — added `.build/`, `.swiftpm/`, `Package.resolved` (SPM build artifacts).
- **`CHANGELOG.md`** / **`package.json`** — version bump to 7.1.5.

## Callouts

- The SPM library product is named `NewRelic`, not `NewRelicAgent` (the pod name) — this is dictated by the agent's [`newrelic-ios-agent-spm`](https://github.com/newrelic/newrelic-ios-agent-spm) package and is correct.
- iOS 15 floor under SPM is enforced by the agent's package; cordova-ios <8 (Pods) keeps its existing minimum.
- The `update-native-agents` workflow's pod sed was changed from `~>.*\" />` (which would have stripped our new `nospm="true"` attribute on the next run) to `~>[^"]*"` (only the version is replaced).

## Test plan

- [ ] **SPM smoke test (cordova-ios 8):** create a fresh Cordova app pinning `cordova-ios ^8.0.1`, install this plugin (`cordova plugin add <path>`), `cordova build ios`. Confirm `platforms/ios/` does **not** contain a `Podfile`/`Podfile.lock` and the Xcode project lists a Swift Package dependency on `newrelic-ios-agent-spm` resolved to `7.7.2`.
- [ ] **Pods regression (cordova-ios 7):** same flow with `cordova-ios@7.1.1`. Confirm `Podfile` exists and references `NewRelicAgent ~> 7.7.2`; no SPM resolution attempted.
- [ ] **Runtime:** with a real iOS app token, run on device and exercise `recordCustomEvent`, `currentSessionId`, `recordError`. Confirm events arrive in the New Relic dashboard.
- [ ] **Workflow dry-run:** trigger `update-native-agents` (workflow_dispatch with the same iOS version) and confirm the diff would now touch `Package.swift` correctly without disturbing `nospm="true"`, and would target `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)